### PR TITLE
Integrate MarkupLM transformers with MiniLM ONNX

### DIFF
--- a/src/her/embeddings/__init__.py
+++ b/src/her/embeddings/__init__.py
@@ -4,10 +4,15 @@ from . import _resolve  # re-export submodule for callers/tests
 from .text_embedder import TextEmbedder
 from .query_embedder import QueryEmbedder
 from .element_embedder import ElementEmbedder
+try:
+    from .markuplm_embedder import MarkupLMEmbedder  # type: ignore
+except Exception:
+    MarkupLMEmbedder = None  # type: ignore
 
 __all__ = [
     "_resolve",
     "TextEmbedder",
     "QueryEmbedder",
     "ElementEmbedder",
+    "MarkupLMEmbedder",
 ]

--- a/src/her/embeddings/markuplm_embedder.py
+++ b/src/her/embeddings/markuplm_embedder.py
@@ -1,0 +1,53 @@
+"""MarkupLM (Transformers) element embedder.
+
+Loads a local MarkupLM model directory (offline) and produces float32
+embeddings for DOM element descriptors. Minimal input is the element "text".
+
+Public API mirrors other embedders:
+  - encode(element: dict) -> np.ndarray[(dim,), float32]
+  - batch_encode(elements: list[dict]) -> np.ndarray[(N, dim), float32]
+
+Guard rails:
+- Does not import onnxruntime or optimum.
+- Requires an installed local Transformers model directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+import torch
+from transformers import AutoProcessor, MarkupLMModel  # type: ignore
+
+
+class MarkupLMEmbedder:
+    def __init__(self, model_dir: str | Path, device: str = "cpu") -> None:
+        self.model_dir = str(Path(model_dir))
+        self.device = torch.device(device)
+        # Load processor and model from local directory
+        self.processor = AutoProcessor.from_pretrained(self.model_dir)
+        self.model = MarkupLMModel.from_pretrained(self.model_dir).to(self.device).eval()
+        # MarkupLM-base hidden size
+        self.dim: int = int(getattr(self.model.config, "hidden_size", 768))
+
+    def _encode_one(self, element: Dict[str, Any]) -> np.ndarray:
+        text = (element.get("text") or "").strip()
+        if not text:
+            return np.zeros((self.dim,), dtype=np.float32)
+        inputs = self.processor(text=[text], return_tensors="pt", truncation=True, padding=True)
+        inputs = {k: v.to(self.device) for k, v in inputs.items()}
+        with torch.no_grad():
+            out = self.model(**inputs).last_hidden_state[:, 0, :]  # CLS token
+        return out.squeeze(0).detach().cpu().float().numpy()
+
+    def encode(self, element: Dict[str, Any]) -> np.ndarray:
+        return self._encode_one(element)
+
+    def batch_encode(self, elements: List[Dict[str, Any]]) -> np.ndarray:
+        if not elements:
+            return np.zeros((0, self.dim), dtype=np.float32)
+        mats = [self._encode_one(e) for e in elements]
+        return np.stack(mats, axis=0)
+

--- a/src/her/models/MODEL_INFO.json
+++ b/src/her/models/MODEL_INFO.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "id": "sentence-transformers/ms-marco-MiniLM-L-6-v3",
     "alias": "e5-small-onnx/model.onnx",
@@ -7,7 +7,7 @@
   },
   {
     "id": "microsoft/markuplm-base",
-    "alias": "markuplm-base-onnx/model.onnx",
+    "alias": "markuplm-base",
     "task": "element-embedding",
     "downloaded_at": "2025-09-03T01:55:24Z"
   }

--- a/tests/embeddings/test_markuplm_transformers.py
+++ b/tests/embeddings/test_markuplm_transformers.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import numpy as np
+import pytest
+
+
+def _installed_markuplm_dir() -> Path | None:
+    d = Path("src/her/models/markuplm-base").resolve()
+    if not d.is_dir():
+        return None
+    # Require weights to be present for a real offline load
+    if not (d / "pytorch_model.bin").exists():
+        return None
+    if not (d / "config.json").exists():
+        return None
+    if not ((d / "tokenizer.json").exists() or (d / "vocab.txt").exists()):
+        return None
+    return d
+
+
+def test_markuplm_transformers_encode_one_offline():
+    d = _installed_markuplm_dir()
+    if d is None:
+        pytest.skip("MarkupLM Transformers model not installed; run scripts/install_models.sh")
+    from her.embeddings.markuplm_embedder import MarkupLMEmbedder
+
+    emb = MarkupLMEmbedder(d)
+    vec = emb.encode({"text": "hello"})
+    assert isinstance(vec, np.ndarray)
+    assert vec.dtype == np.float32
+    assert vec.shape == (emb.dim,)
+    # Base model hidden size is 768
+    assert emb.dim == 768
+
+
+def test_markuplm_transformers_batch_encode():
+    d = _installed_markuplm_dir()
+    if d is None:
+        pytest.skip("MarkupLM Transformers model not installed; run scripts/install_models.sh")
+    from her.embeddings.markuplm_embedder import MarkupLMEmbedder
+
+    emb = MarkupLMEmbedder(d)
+    vecs = emb.batch_encode([{"text": "a"}, {"text": "b"}])
+    assert isinstance(vecs, np.ndarray)
+    assert vecs.dtype == np.float32
+    assert vecs.shape == (2, emb.dim)
+

--- a/tests/embeddings/test_resolver_paths.py
+++ b/tests/embeddings/test_resolver_paths.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+import os
+import json
+import shutil
+import tempfile
+import pytest
+
+from her.embeddings import _resolve
+
+
+def _make_root(tmp: Path) -> Path:
+    root = tmp / "models"
+    root.mkdir(parents=True, exist_ok=True)
+    # Minimal MODEL_INFO for text to avoid unrelated failures
+    (root / "e5-small-onnx").mkdir(parents=True, exist_ok=True)
+    mi = [
+        {
+            "id": "sentence-transformers/ms-marco-MiniLM-L-6-v3",
+            "alias": "e5-small-onnx/model.onnx",
+            "task": "text-embedding",
+            "downloaded_at": "2025-01-01T00:00:00Z",
+        }
+    ]
+    (root / "MODEL_INFO.json").write_text(json.dumps(mi), encoding="utf-8")
+    # Provide stub files for text model to satisfy exists checks
+    (root / "e5-small-onnx" / "model.onnx").write_bytes(b"\x00")
+    (root / "e5-small-onnx" / "tokenizer.json").write_text("{}", encoding="utf-8")
+    return root
+
+
+def test_resolver_transformers_fallback_when_only_markuplm_transformers_present(monkeypatch):
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        root = _make_root(tmp)
+        tdir = root / "markuplm-base"
+        tdir.mkdir(parents=True, exist_ok=True)
+        (tdir / "config.json").write_text("{}", encoding="utf-8")
+        (tdir / "tokenizer.json").write_text("{}", encoding="utf-8")
+        (tdir / "pytorch_model.bin").write_bytes(b"\x00")
+        monkeypatch.setenv("HER_MODELS_DIR", str(root))
+        mp = _resolve.resolve_element_embedding()
+        assert mp.framework == "transformers"
+        assert mp.model_dir and mp.model_dir.exists()
+
+
+def test_resolver_onnx_first_when_only_markuplm_onnx_present(monkeypatch):
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        root = _make_root(tmp)
+        o_dir = root / "markuplm-base-onnx"
+        o_dir.mkdir(parents=True, exist_ok=True)
+        (o_dir / "model.onnx").write_bytes(b"\x00")
+        (o_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
+        monkeypatch.setenv("HER_MODELS_DIR", str(root))
+        mp = _resolve.resolve_element_embedding()
+        assert mp.framework == "onnx"
+        assert mp.onnx and mp.onnx.exists()
+        assert mp.tokenizer and mp.tokenizer.exists()
+
+
+def test_resolver_raises_when_neither_present(monkeypatch):
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        root = _make_root(tmp)
+        monkeypatch.setenv("HER_MODELS_DIR", str(root))
+        with pytest.raises(_resolve.ResolverError):
+            _resolve.resolve_element_embedding()
+


### PR DESCRIPTION
Add MarkupLM (Transformers) support for element embeddings, allowing for more advanced element representation while maintaining MiniLM (ONNX) for text.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd8fbc6d-7d05-41e2-ade9-60090b6c2d43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bd8fbc6d-7d05-41e2-ade9-60090b6c2d43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

