### PR TITLE
Check her module for import errors

### DIFF
--- a/src/her/__init__.py
+++ b/src/her/__init__.py
@@ -19,20 +19,52 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
+# Import core classes that exist
+try:
+    from .core.pipeline import HybridPipeline
+    from .core.compat import HERPipeline
+except ImportError as e:
+    # Handle missing dependencies gracefully
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.warning(f"Core pipeline dependencies not available: {e}")
+    HybridPipeline = None
+    HERPipeline = None
+
+from .core.config import PipelineConfig
+
+# Import CLI classes that exist
+try:
+    from .cli.cli_api import (
+        ResilienceManager,
+        WaitStrategy,
+        InputValidator,
+        DOMValidator,
+        FormValidator,
+        HybridElementRetrieverClient
+    )
+except ImportError:
+    # CLI classes not available
+    ResilienceManager = None
+    WaitStrategy = None
+    InputValidator = None
+    DOMValidator = None
+    FormValidator = None
+    HybridElementRetrieverClient = None
+
+# Version information
+__version__ = "0.1.0"
+
 __all__ = [
-    "HybridClient",
-    "HybridElementRetriever",
-    "HybridElementRetrieverClient",
     "HybridPipeline",
-    "HERPipeline",
-    "resolve_model_paths",
+    "HERPipeline", 
     "PipelineConfig",
     "ResilienceManager",
     "WaitStrategy",
     "InputValidator",
     "DOMValidator",
     "FormValidator",
-    "AccessibilityValidator",
+    "HybridElementRetrieverClient",
     "gateway_server",
     "HerAgent",
     "__version__"

--- a/src/her/vectordb/faiss_index.py
+++ b/src/her/vectordb/faiss_index.py
@@ -1,10 +1,24 @@
 # Alias to current FAISS store
-from .faiss_store import InMemoryVectorStore as FaissStore, FAISSStore
+try:
+    from .faiss_store import InMemoryVectorStore as FaissStore, FAISSStore
+except ImportError as e:
+    # Handle missing dependencies gracefully
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.warning(f"FAISS dependencies not available: {e}")
+    
+    # Create dummy classes for when dependencies are missing
+    class FaissStore:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("FAISS dependencies not available. Install with: pip install faiss-cpu numpy")
+    
+    class FAISSStore(FaissStore):
+        pass
 
 # Create aliases for the methods that exist
 def build_faiss_index(dim=768):
     """Build a new FAISS index."""
-    return InMemoryVectorStore(dim=dim)
+    return FaissStore(dim=dim)
 
 def search_vectors(store, query, k=5, threshold=None):
     """Search vectors in the store."""


### PR DESCRIPTION
Fix import errors and improve graceful handling of missing optional dependencies in `__init__.py` and `faiss_index.py`.

The previous implementation caused import failures when optional dependencies (like `numpy` or `faiss-cpu`) were not installed, or when `__init__.py` attempted to export non-existent classes. This PR resolves these issues by making imports conditional and providing informative error messages, allowing the core library to be imported even if optional components' dependencies are missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-40cf2ead-ee98-40ae-8e5b-11a494bef7b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40cf2ead-ee98-40ae-8e5b-11a494bef7b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

