### PR TITLE
Fix her init import statement

### DIFF
--- a/src/her/__init__.py
+++ b/src/her/__init__.py
@@ -8,14 +8,9 @@ def __getattr__(name):
         import importlib
         mod = importlib.import_module('.gateway_server', __name__)
         return mod
-    # Provide direct access to the high-level runtime orchestrator.
+    # HerAgent is not available in this version
     if name == "HerAgent":
-        try:
-            from .runtime.agent import HerAgent as _HA
-            return _HA
-        except Exception:
-            # If runtime dependencies (e.g. Playwright) are missing, return None
-            return None
+        return None
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
@@ -66,6 +61,5 @@ __all__ = [
     "FormValidator",
     "HybridElementRetrieverClient",
     "gateway_server",
-    "HerAgent",
     "__version__"
 ]


### PR DESCRIPTION
Remove non-existent `HerAgent` import and reference to fix import errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e770d46-88b5-4172-ac30-76bc9ced58ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e770d46-88b5-4172-ac30-76bc9ced58ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

